### PR TITLE
Fix code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/controllers/post.controller.js
+++ b/controllers/post.controller.js
@@ -78,7 +78,7 @@ if(post){
 }
     
 
-    const boardCreated = await Board.findOne({ boardTitle: req.body.boardTitle });
+    const boardCreated = await Board.findOne({ boardTitle: { $eq: req.body.boardTitle } });
     if(boardCreated){
         boardCreated.posts.push(post._id);
         await boardCreated.save();


### PR DESCRIPTION
Fixes [https://github.com/namankoolwal/Pinterest-Backend/security/code-scanning/1](https://github.com/namankoolwal/Pinterest-Backend/security/code-scanning/1)

To fix the problem, we need to ensure that the user input is properly sanitized or validated before being used in the MongoDB query. The best way to fix this issue is to use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This approach is straightforward and does not change the existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
