### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/views/createPost.ejs
+++ b/views/createPost.ejs
@@ -124,7 +124,7 @@
     const fileName = file ? file.name : 'No file selected';
     imgNameDisplay.textContent = fileName;
 
-    if (file) {
+    if (file && file.type.startsWith('image/')) {
       const imageUrl = URL.createObjectURL(file);
       imagePreview.src = imageUrl;
       imagePreview.style.display = 'block';
@@ -158,7 +158,7 @@
       const fileName = file.name;
       imgNameDisplay.textContent = fileName;
 
-      if (file) {
+      if (file && file.type.startsWith('image/')) {
         const imageUrl = URL.createObjectURL(file);
         imagePreview.src = imageUrl;
         imagePreview.style.display = 'block';


### PR DESCRIPTION
Fixes [https://github.com/namankoolwal/Pinterest-Backend/security/code-scanning/2](https://github.com/namankoolwal/Pinterest-Backend/security/code-scanning/2)

To fix the problem, we should ensure that the `imageUrl` generated from `URL.createObjectURL(file)` is handled securely. One way to do this is to validate the file type before creating the object URL and assigning it to the `src` attribute of the `img` element. This ensures that only valid image files are processed.

1. Validate the file type to ensure it is an image before creating the object URL.
2. Update the event listeners to include this validation step.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
