### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/views/feed.ejs
+++ b/views/feed.ejs
@@ -72,17 +72,33 @@
 <%- include('./partials/footer.ejs') %> 
 
 <script>
+  function isValidUrl(string) {
+    try {
+      new URL(string);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
   document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.save-button').forEach(button => {
       button.addEventListener('click', event => {
         event.preventDefault(); // Prevent the default behavior
         const imageUrl = button.getAttribute('data-image-url');
-        const link = document.createElement('a');
-        link.href = imageUrl;
-        link.download = 'image.png'; // Set the default download name for the image
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
+        if (isValidUrl(imageUrl)) {
+          const link = document.createElement('a');
+          link.href = imageUrl;
+          link.download = 'image.png'; // Set the default download name for the image
+          document.body.appendChild(link);
+          link.click();
+          document.body.removeChild(link);
+        } else {
+          console.error('Invalid URL:', imageUrl);
+        }
+          document.body.removeChild(link);
+        } else {
+          console.error('Invalid URL:', imageUrl);
+        }
       });
     });
   });


### PR DESCRIPTION
Fixes [https://github.com/namankoolwal/Pinterest-Backend/security/code-scanning/3](https://github.com/namankoolwal/Pinterest-Backend/security/code-scanning/3)

To fix the problem, we need to ensure that the `imageUrl` is properly sanitized or validated before it is used to set the `href` attribute of the anchor element. One effective way to do this is to use a URL validation library to ensure that the `imageUrl` is a valid and safe URL.

- Use a URL validation library to check the `imageUrl` before using it.
- Modify the JavaScript code to include the validation step.
- Ensure that the validation library is imported and used correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
